### PR TITLE
Update boofcv from 0.26 to 1.1.2 and Java from 8 to 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
       with:
-        java-version: 8
+        java-version: 11
         distribution: temurin
     - run: mvn -B clean package --no-transfer-progress
     - uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ FormScanner is an OMR (Optical Mark Recognition) software that automatically mar
 ## Build requirements
 
 * [Git client](https://git-scm.com/)
-* [Java 8](https://javaalmanac.io/jdk/8/)
+* [Java 11](https://javaalmanac.io/jdk/11/)
 * [Maven 3](https://maven.apache.org/)
 
 ## Compiling the Software

--- a/formscanner-api/pom.xml
+++ b/formscanner-api/pom.xml
@@ -108,7 +108,7 @@
 <!-- 		</dependency> -->
 		<dependency>
 			<groupId>org.boofcv</groupId>
-			<artifactId>all</artifactId>
+			<artifactId>boofcv-core</artifactId>
 			<version>${boofcv.version}</version>
 		</dependency>
 	</dependencies>
@@ -118,7 +118,7 @@
 		<nexus-staging-maven-plugin.version>1.6.3</nexus-staging-maven-plugin.version>
 		<maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
 		<zxing.version>3.2.0</zxing.version>
-		<boofcv.version>0.26</boofcv.version>
+		<boofcv.version>1.1.2</boofcv.version>
 <!-- 		<commons-codec.version>1.10</commons-codec.version> -->
 	</properties>
 </project>

--- a/formscanner-api/src/main/java/com/albertoborsetta/formscanner/api/FormScannerDetector.java
+++ b/formscanner-api/src/main/java/com/albertoborsetta/formscanner/api/FormScannerDetector.java
@@ -19,7 +19,6 @@ import boofcv.abst.feature.detdesc.DetectDescribePoint;
 import boofcv.abst.feature.detect.interest.ConfigFastHessian;
 import boofcv.factory.feature.associate.FactoryAssociation;
 import boofcv.factory.feature.detdesc.FactoryDetectDescribe;
-import boofcv.struct.feature.BrightFeature;
 import boofcv.struct.image.GrayF32;
 
 import java.awt.image.BufferedImage;

--- a/formscanner-api/src/main/java/com/albertoborsetta/formscanner/api/FormScannerDetectorEngine.java
+++ b/formscanner-api/src/main/java/com/albertoborsetta/formscanner/api/FormScannerDetectorEngine.java
@@ -7,20 +7,18 @@ import boofcv.abst.feature.associate.AssociateDescription;
 import boofcv.abst.feature.associate.ScoreAssociation;
 import boofcv.abst.feature.detdesc.DetectDescribePoint;
 import boofcv.abst.feature.detect.interest.ConfigFastHessian;
+import boofcv.factory.feature.associate.ConfigAssociateGreedy;
 import boofcv.factory.feature.associate.FactoryAssociation;
 import boofcv.factory.feature.detdesc.FactoryDetectDescribe;
 import boofcv.io.image.ConvertBufferedImage;
-import boofcv.struct.feature.BrightFeature;
 import boofcv.struct.feature.TupleDesc;
+import boofcv.struct.feature.TupleDesc_F64;
 import boofcv.struct.image.GrayF32;
 import boofcv.struct.image.ImageGray;
 import georegression.struct.point.Point2D_F64;
 
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
-
-import org.ddogleg.struct.FastQueue;
-import org.ejml.data.DenseMatrix64F;
 
 /**
  *
@@ -35,15 +33,15 @@ public class FormScannerDetectorEngine {
     
     private BufferedImage image;
 
-    private DetectorEngine<GrayF32, BrightFeature> detectorEngine;
+    private DetectorEngine<GrayF32, TupleDesc_F64> detectorEngine;
     
     public FormScannerDetectorEngine(int threshold, int density, int size, BufferedImage image) {
     	Class<GrayF32> imageType = GrayF32.class;
-		DetectDescribePoint<GrayF32, BrightFeature> detDesc = FactoryDetectDescribe.surfStable(new ConfigFastHessian(1, 10, 300, 1, 9, 4, 4), null, null, imageType);
-		ScoreAssociation<BrightFeature> scorer = FactoryAssociation.defaultScore(detDesc.getDescriptionType());
-		AssociateDescription<BrightFeature> associate = FactoryAssociation.greedy(scorer, Double.MAX_VALUE, true);
+		DetectDescribePoint<GrayF32, TupleDesc_F64> detDesc = FactoryDetectDescribe.surfStable(new ConfigFastHessian(1, 10, 300, 1, 9, 4, 4), null, null, imageType);
+		ScoreAssociation<TupleDesc_F64> scorer = FactoryAssociation.defaultScore(detDesc.getDescriptionType());
+		AssociateDescription<TupleDesc_F64> associate = FactoryAssociation.greedy(new ConfigAssociateGreedy(true, Double.MAX_VALUE), scorer);
 
-		detectorEngine = new DetectorEngine<GrayF32, BrightFeature>(detDesc, associate, imageType);
+		detectorEngine = new DetectorEngine<GrayF32, TupleDesc_F64>(detDesc, associate, imageType);
 		
 		detectorEngine.describeSourceImage(image);
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Version 0.26 had a dependency on opencv native binaries which where not available on osx-aarch64. Also this brings down the installation size from 180MB to 25MB.

This change also requires an update to Java 11.